### PR TITLE
Update axi_master.v

### DIFF
--- a/MyCodes/axi_ip/rtl/pcores/axi_master_v1_00_a/hdl/verilog/axi_master.v
+++ b/MyCodes/axi_ip/rtl/pcores/axi_master_v1_00_a/hdl/verilog/axi_master.v
@@ -424,8 +424,7 @@ always @(posedge ACLK)
   end
 
 //WLAST generation on the MSB of a counter underflow
-assign wlast = wlen_count[C_WLEN_COUNT_WIDTH-1];
-
+	assign wlast = (wlen_count == 0) ;
 /* Burst length counter. Uses extra counter register bit to indicate terminal
  count to reduce decode logic */    
 always @(posedge ACLK)


### PR DESCRIPTION
the maximum value of wlen_count can be 14 which is in binary 001110 where 5th bit is always 0 but you are assigning 5th bit of wlen_count to wlast where C_WLEN_COUNT_WIDTH is 6. so, it will be 5th bit of wlen_count but it can never go to 16 where we can get 5th bit as 1 as we are down counting  (OR) decrementing wlen_count